### PR TITLE
Do not include glext.h if glew.h is also included

### DIFF
--- a/include/GLFont/GLConfig.h
+++ b/include/GLFont/GLConfig.h
@@ -9,7 +9,6 @@
 #include <GL/gl.h>
 
 #if defined(__APPLE__) || defined(__linux__)
- #include <GL/glext.h>
  #include <GL/glx.h>
 #endif
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/65009898/incompatible-function-prototypes-between-glew-h-and-glext-h