### PR TITLE
Switch from find_package(GLFW3) to find_package(glfw3)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(GLFW3 REQUIRED)
+find_package(glfw3 NO_MODULE REQUIRED)
 
 set (TEST_WINDOW_SRC
     src/TestWindow.cpp


### PR DESCRIPTION
`find_package(GLFW3)` was deprecated since https://github.com/robotology/ycm-cmake-modules/pull/441 .